### PR TITLE
Reject orphaned and widowed lines with {nowidow}

### DIFF
--- a/CV.tex
+++ b/CV.tex
@@ -125,6 +125,8 @@
 \displaywidowpenalty = 10000
 \widowpenalty        = 10000
 
+\usepackage[defaultlines=100,all]{nowidow} % rejects all orphaned and widowed lines
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main document
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Dr. Rieck, 

Thank you for this splendid work. I have customized this beautiful template for my own purposes. You may find own full 'public template' version here: https://github.com/historical-theology/cv

Please let me know if you would like me to change anything about how I have phrased my attribution to you (and Dr. Dario Taraborelli).

Of my many small customizations, I think that this one line is the most universally helpful -- so much so that I recommend including either it _or_ something like it in your main document (or a suggestion to use it in the README). To make a long story short, one of the most irksome things about trying to manage an ever-changing academic CV in a word processor is that orphaned and widowed lines inevitably abound. Using {nowidow} (or another, comparable package) in LaTeX is a tremendously helpful alternative.

Cheers, and God bless,
Corey
